### PR TITLE
Various changes to cleanup and simplify the code.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,51 +29,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.atlassian.sal</groupId>
-            <artifactId>sal-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
             <artifactId>bitbucket-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.bitbucket.server</groupId>
-            <artifactId>bitbucket-spi</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.bitbucket.server</groupId>
-            <artifactId>bitbucket-page-objects</artifactId>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>servlet-api</artifactId>
-                    <groupId>org.mortbay.jetty</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.soy</groupId>
-            <artifactId>soy-template-renderer-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.10</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <artifactId>bitbucket-rest-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -82,61 +44,96 @@
             <artifactId>activeobjects-plugin</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.atlassian.plugins.rest</groupId>
+            <artifactId>atlassian-rest-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
             <scope>compile</scope>
         </dependency>
-
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-runtime</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
             <scope>runtime</scope>
         </dependency>
-
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-            <version>1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugins.rest</groupId>
-            <artifactId>atlassian-rest-common</artifactId>
+            <groupId>com.atlassian.soy</groupId>
+            <artifactId>soy-template-renderer-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.bitbucket.server</groupId>
+            <artifactId>bitbucket-it-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.bitbucket.server</groupId>
+            <artifactId>bitbucket-page-objects</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.atlassian.bitbucket.server</groupId>
+            <artifactId>bitbucket-test-util</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
             <version>2.5.1</version>
             <scope>test</scope>
         </dependency>
-        <!-- WIRED TEST RUNNER DEPENDENCIES -->
         <dependency>
-            <groupId>com.atlassian.plugins</groupId>
-            <artifactId>atlassian-plugins-osgi-testrunner</artifactId>
-            <version>${plugin.testrunner.version}</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
-            <version>1.1.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.2.2-atlassian-1</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -145,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.4.2</version>
+                <version>2.5.3</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
@@ -154,6 +151,17 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20</version>
+                <configuration>
+                    <excludes>
+                        <exclude>it/**/*.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
                 <artifactId>bitbucket-maven-plugin</artifactId>
@@ -181,9 +189,19 @@
                         <!-- Ensure plugin is Spring powered -->
                         <Spring-Context>*</Spring-Context>
                     </instructions>
+                    <testGroups>
+                        <testGroup>
+                            <id>bitbucket-integration</id>
+                            <includes>
+                                <include>it/**/*.java</include>
+                            </includes>
+                            <productIds>
+                                <productId>bitbucket</productId>
+                            </productIds>
+                        </testGroup>
+                    </testGroups>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>com.atlassian.plugin</groupId>
                 <artifactId>atlassian-spring-scanner-maven-plugin</artifactId>
@@ -209,17 +227,104 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- This profile supports executing DAO tests for plugins against a real database by providing database-specific
+             configuration when the real-database profile is activated.
+
+             By default, all of the ActiveObjects tests use an in-memory H2 database to run. During development, this
+             is likely to be sufficient. However, to ensure our bundled plugins run correctly on all of our supported
+             databases, it is beneficial to run our tests against them. Running the tests will verify that:
+             - Our usage of ActiveObjects is consistent cross database
+             - ActiveObjects schema creation works
+
+             net.java.ao.test.jdbc.DatabaseUpdater is used to populate data for these tests.
+
+             Unfortunately, Maven only allows a single property when configuring activation. However, correct execution
+             of this profile requires that the following properties _all_ be defined:
+             - jdbc.password
+             - jdbc.url
+             - jdbc.user
+             The presence of jdbc.url activates the profile, so you do not need to use -Preal-database. For example, to
+             run the unit tests against MySQL, you could run the following:
+             > mvn clean install -Djdbc.url=jdbc:mysql://localhost:3306/bitbucket \
+             >     -Djdbc.user=bitbucket -Djdbc.password=someCoolPassword
+             For simplicity, you should probably avoid exotic characters in your password and other properties; it has
+             not been tested how they might affect Surefire's execution.
+
+             This profile should be safe for use by developers if they wish to perform testing against a specific
+             database, perhaps in response to a failed build. -->
+        <profile>
+            <id>real-database</id>
+            <activation>
+                <property>
+                    <name>jdbc.url</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <groups>com.atlassian.bitbucket.ao.AbstractAoDaoTest</groups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <!-- Required so that we can target classes extending AbstractAoDaoTest -->
+                <dependency>
+                    <groupId>com.atlassian.bitbucket.server</groupId>
+                    <artifactId>bitbucket-test-util</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <!-- The drivers below are test scope for executing the AO tests against all supported DBs -->
+                <!-- Do NOT change the scope, as these jars should not be part of the plugin -->
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>sqljdbc</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.oracle</groupId>
+                    <artifactId>ojdbc7</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hsqldb</groupId>
+                    <artifactId>hsqldb</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <properties>
+                <!-- Integration tests won't use the real database, so skip them when one is configured. -->
+                <skipITs>true</skipITs>
+            </properties>
+        </profile>
+    </profiles>
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <bitbucket.version>4.6.1</bitbucket.version>
-        <bitbucket.data.version>4.6.1</bitbucket.data.version>
-        <amps.version>6.2.11</amps.version>
-        <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.12</atlassian.spring.scanner.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <allow.google.tracking>false</allow.google.tracking>
+        <amps.version>6.3.3</amps.version>
         <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml and the key to generate bundle. -->
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
-        <allow.google.tracking>false</allow.google.tracking>
+        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <bitbucket.version>4.6.4</bitbucket.version>
+        <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
     </properties>
 
     <licenses>
@@ -272,7 +377,7 @@
         <connection>scm:git:git@github.com:topicusfinan/bitbucket-webhooks-plugin.git</connection>
         <url>scm:git:git@github.com:topicusfinan/bitbucket-webhooks-plugin.git</url>
         <developerConnection>scm:git:git@github.com:topicusfinan/bitbucket-webhooks-plugin.git</developerConnection>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
   </scm>
 
 </project>

--- a/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
+++ b/src/main/java/nl/topicus/bitbucket/api/PullRequestListener.java
@@ -3,10 +3,11 @@ package nl.topicus.bitbucket.api;
 import com.atlassian.bitbucket.event.branch.BranchCreatedEvent;
 import com.atlassian.bitbucket.event.branch.BranchDeletedEvent;
 import com.atlassian.bitbucket.event.pull.*;
-import com.atlassian.bitbucket.event.repository.RepositoryPushEvent;
+import com.atlassian.bitbucket.event.repository.RepositoryDeletionRequestedEvent;
 import com.atlassian.bitbucket.event.repository.RepositoryRefsChangedEvent;
 import com.atlassian.bitbucket.event.tag.TagCreatedEvent;
 import com.atlassian.bitbucket.nav.NavBuilder;
+import com.atlassian.bitbucket.pull.IllegalPullRequestStateException;
 import com.atlassian.bitbucket.pull.PullRequest;
 import com.atlassian.bitbucket.pull.PullRequestService;
 import com.atlassian.bitbucket.repository.Repository;
@@ -31,170 +32,251 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
 
 @Component
-public class PullRequestListener implements DisposableBean
+public class PullRequestListener implements DisposableBean, InitializingBean
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(PullRequestListener.class);
 
-    private EventPublisher eventPublisher;
-    private CloseableHttpClient httpClient;
-    private NavBuilder navBuilder;
-    private WebHookConfigurationDao webHookConfigurationDao;
-    private PullRequestService pullRequestService;
-    private ApplicationPropertiesService applicationPropertiesService;
+    private final ApplicationPropertiesService applicationPropertiesService;
+    private final EventPublisher eventPublisher;
+    private final ExecutorService executorService;
+    private final CloseableHttpClient httpClient;
+    private final NavBuilder navBuilder;
+    private final PullRequestService pullRequestService;
+    private final WebHookConfigurationDao webHookConfigurationDao;
 
     @Autowired
-    public PullRequestListener(@ComponentImport EventPublisher eventPublisher,
-                               @ComponentImport PullRequestService pullRequestService,
+    public PullRequestListener(@ComponentImport ApplicationPropertiesService applicationPropertiesService,
+                               @ComponentImport EventPublisher eventPublisher,
+                               @ComponentImport ExecutorService executorService,
                                HttpClientFactory httpClientFactory,
                                @ComponentImport NavBuilder navBuilder,
-                               @ComponentImport ApplicationPropertiesService applicationPropertiesService,
+                               @ComponentImport PullRequestService pullRequestService,
                                WebHookConfigurationDao webHookConfigurationDao)
     {
-        this.eventPublisher = eventPublisher;
-        this.httpClient = httpClientFactory.create();
-        this.navBuilder = navBuilder;
-        this.webHookConfigurationDao = webHookConfigurationDao;
-        this.pullRequestService = pullRequestService;
         this.applicationPropertiesService = applicationPropertiesService;
+        this.eventPublisher = eventPublisher;
+        this.executorService = executorService;
+        this.navBuilder = navBuilder;
+        this.pullRequestService = pullRequestService;
+        this.webHookConfigurationDao = webHookConfigurationDao;
+
+        httpClient = httpClientFactory.create();
+    }
+
+    @Override
+    public void afterPropertiesSet()
+    {
         eventPublisher.register(this);
     }
 
     @EventListener
-    public void createdEvent(PullRequestOpenedEvent event) throws IOException
+    public void onPullRequestCreated(PullRequestOpenedEvent event)
     {
-        sendPullRequestEvent(event, EventType.PULL_REQUEST_CREATED);
+        sendPullRequestEvent(event, EventType.PULL_REQUEST_CREATED, true);
+    }
+
+    @Override
+    public void destroy()
+    {
+        eventPublisher.unregister(this);
+
+        try
+        {
+            httpClient.close();
+        }
+        catch (IOException e)
+        {
+            LOGGER.warn("Failed to close HttpClient; it will be abandoned", e);
+        }
     }
 
     @EventListener
-    public void updatedEvent(PullRequestUpdatedEvent event) throws IOException
-    {
-        sendPullRequestEvent(event, EventType.PULL_REQUEST_UPDATED);
-    }
-
-    @EventListener
-    public void reopenedEvent(PullRequestReopenedEvent event) throws IOException
+    public void onPullRequestUpdated(PullRequestUpdatedEvent event)
     {
         sendPullRequestEvent(event, EventType.PULL_REQUEST_REOPENED);
     }
 
     @EventListener
-    public void rescopedEvent(PullRequestRescopedEvent event) throws IOException
+    public void onPullRequestReopened(PullRequestReopenedEvent event)
     {
-        final PullRequest pullRequest = event.getPullRequest();
-
-        // see this atlassian page for explanation of the logic in this handler:
-        // https://answers.atlassian.com/questions/239988
-
-        // only trigger when changes were pushed to the "from" side of the PR
-        if (!event.getPreviousFromHash().equals(pullRequest.getFromRef().getLatestCommit()))
+        PullRequest pullRequest = event.getPullRequest();
+        if (pullRequest.getFromRef().getLatestCommit().equals(event.getPreviousFromHash()) &&
+                pullRequest.getToRef().getLatestCommit().equals(event.getPreviousToHash()))
         {
-            // canMerge forces the update of refs in the destination repository
-            pullRequestService.canMerge(pullRequest.getToRef().getRepository().getId(), pullRequest.getId());
-            sendPullRequestEvent(event, EventType.PULL_REQUEST_RESCOPED);
+            // If the PullRequest's from and to refs were not updated when it was reopend, trigger webhooks
+            // for the update. Otherwise, if _either_ ref changed, a rescope event will also be raised. Let
+            // that trigger webhooks instead, to ensure the pull request's refs are updated on disk
+            sendPullRequestEvent(event, EventType.PULL_REQUEST_UPDATED);
         }
     }
 
     @EventListener
-    public void mergedEvent(PullRequestMergedEvent event) throws IOException
+    public void onPullRequestRescoped(PullRequestRescopedEvent event)
     {
+        // see this atlassian page for explanation of the logic in this handler:
+        // https://answers.atlassian.com/questions/239988
+
+        // only trigger when changes were pushed to the "from" side of the PR
+        if (event.isFromHashUpdated())
+        {
+            sendPullRequestEvent(event, EventType.PULL_REQUEST_RESCOPED, true);
+        }
+    }
+
+    @EventListener
+    public void onPullRequestMerged(PullRequestMergedEvent event)
+    {
+        // Note that onRepositoryRefsChanged is _also_ called for this same event. It triggers a different
+        // set of webhooks, however, so the double-handling is intentional
         sendPullRequestEvent(event, EventType.PULL_REQUEST_MERGED);
     }
 
     @EventListener
-    public void declinedEvent(PullRequestDeclinedEvent event) throws IOException
+    public void onPullRequestDeclined(PullRequestDeclinedEvent event)
     {
         sendPullRequestEvent(event, EventType.PULL_REQUEST_DECLINED);
     }
 
+    /**
+     * Delete configurations for any webhooks associated with the repository.
+     * <p>
+     * Even if the repository was "recreated", it would have a new ID, which means the old configurations would still
+     * not be reused.
+     * <p>
+     * This event is raised as part fo the same database transaction where the repository is being deleted. If that
+     * transaction is committed, deleting the configurations will also commit. Otherwise, if something goes wrong,
+     * or if another listener {@link RepositoryDeletionRequestedEvent#cancel cancels} the event, this change will be
+     * rolled back as part of that transaction.
+     *
+     * @param event the deletion request
+     */
     @EventListener
-    public void branchDeletedEvent(BranchDeletedEvent event) throws IOException {
-        repoChangedEvent(event, EventType.BRANCH_DELETED);
+    public void onRepositoryDeletionRequested(RepositoryDeletionRequestedEvent event) {
+        // If the event has already been canceled by another listener, don't bother deleting. The transaction is
+        // going to be rolled back anyway
+        if (!event.isCanceled()) {
+            webHookConfigurationDao.deleteWebhookConfigurations(event.getRepository());
+        }
     }
 
     @EventListener
-    public void branchCreatedEvent(BranchCreatedEvent event) throws IOException {
-        repoChangedEvent(event, EventType.BRANCH_CREATED);
-    }
-
-    @EventListener
-    public void tagCreatedEvent(TagCreatedEvent event) throws IOException {
-        repoChangedEvent(event, EventType.TAG_CREATED);
-    }
-
-    @EventListener
-    public void repositoryPushEvent(RepositoryPushEvent event) throws IOException {
-        repoChangedEvent(event, EventType.REPO_PUSH);
-    }
-
-
-    public void repoChangedEvent(RepositoryRefsChangedEvent event, EventType eventType) throws IOException
+    public void onRepositoryRefsChanged(RepositoryRefsChangedEvent event)
     {
-        BitbucketPushEvent pushEvent = Events.createPushEvent(event, applicationPropertiesService);
-        sendEvents(pushEvent, event.getRepository(), eventType);
+        executorService.submit(() -> {
+            BitbucketPushEvent pushEvent = Events.createPushEvent(event, applicationPropertiesService);
+            sendEvents(pushEvent, event.getRepository(), chooseRefsChangedEvent(event));
+        });
     }
 
-    private void sendPullRequestEvent(PullRequestEvent event, EventType eventType) throws IOException
+    private static EventType chooseRefsChangedEvent(RepositoryRefsChangedEvent event)
     {
-        BitbucketServerPullRequestEvent pullRequestEvent = Events.createPullrequestEvent(event,
-                                                                                         applicationPropertiesService);
-        Repository repository = event.getPullRequest().getToRef().getRepository();
-        String prUrl = navBuilder.repo(repository).pullRequest(event.getPullRequest().getId()).buildAbsolute();
-        pullRequestEvent.getPullrequest().setLink(prUrl);
-        sendEvents(pullRequestEvent, repository, eventType);
+        if (event instanceof BranchCreatedEvent)
+        {
+            return EventType.BRANCH_CREATED;
+        }
+        if (event instanceof BranchDeletedEvent)
+        {
+            return EventType.BRANCH_DELETED;
+        }
+        if (event instanceof TagCreatedEvent)
+        {
+            return EventType.TAG_CREATED;
+        }
+        return EventType.REPO_PUSH;
     }
 
-    private void sendEvents(Object event, Repository repo, EventType eventType) throws IOException
+    private void sendPullRequestEvent(PullRequestEvent event, EventType eventType)
     {
-        Header[] headers = {
+        sendPullRequestEvent(event, eventType, false);
+    }
+
+    private void sendPullRequestEvent(PullRequestEvent event, EventType eventType, boolean updateRefs)
+    {
+        executorService.submit(() -> {
+            PullRequest pullRequest = event.getPullRequest();
+            if (updateRefs && pullRequest.isOpen())
+            {
+                try
+                {
+                    pullRequestService.canMerge(pullRequest.getToRef().getRepository().getId(), pullRequest.getId());
+                }
+                catch (IllegalPullRequestStateException e)
+                {
+                    // Logging "e.getMessage()" rather than "e" here is intentional. We don't want to spam
+                    // the full stack trace in the logs; it doesn't add anything here.
+                    LOGGER.debug("{}: {}", pullRequest, e.getMessage());
+                }
+            }
+
+            Repository repository = pullRequest.getToRef().getRepository();
+            String prUrl = navBuilder.repo(repository).pullRequest(pullRequest.getId()).buildAbsolute();
+
+            BitbucketServerPullRequestEvent pullRequestEvent =
+                    Events.createPullrequestEvent(event, applicationPropertiesService);
+            pullRequestEvent.getPullrequest().setLink(prUrl);
+
+            sendEvents(pullRequestEvent, repository, eventType);
+        });
+    }
+
+    private void sendEvents(Object event, Repository repo, EventType eventType)
+    {
+        String body;
+        try
+        {
+            body = new ObjectMapper().writeValueAsString(event);
+        }
+        catch (IOException e)
+        {
+            LOGGER.error("[repo: {}]| Failed to marshal {} payload to JSON. The event will be discarded",
+                    repo, eventType);
+            return;
+        }
+
+        HttpPost post = new HttpPost();
+        post.setEntity(new StringEntity(body, ContentType.APPLICATION_JSON));
+        post.setHeaders(new Header[]{
                 new BasicHeader("X-Event-Key", eventType.getHeaderValue()),
                 new BasicHeader("X-Bitbucket-Type", "server")
-        };
+        });
 
-        ObjectMapper mapper = new ObjectMapper();
-        String jsonBody = mapper.writeValueAsString(event);
-        StringEntity bodyEntity = new StringEntity(jsonBody, ContentType.APPLICATION_JSON);
         for (WebHookConfiguration webHookConfiguration : webHookConfigurationDao.getEnabledWebHookConfigurations(repo, eventType))
         {
-            HttpPost post = new HttpPost(webHookConfiguration.getURL());
-            post.setHeaders(headers);
-            post.setEntity(bodyEntity);
+            post.setURI(URI.create(webHookConfiguration.getURL()));
+
             try (CloseableHttpResponse response = httpClient.execute(post))
             {
                 int statusCode = response.getStatusLine().getStatusCode();
                 if (statusCode >= 400)
                 {
                     LOGGER.error(
-                            "[repo: {}]| Something when wrong while posting (response code:{}) the following body to webhook: [{}({})] \n{}",
+                            "[repo: {}]| Something went wrong while posting (response code:{}) the following body to webhook: [{}({})] \n{}",
                             repo,
                             statusCode,
                             webHookConfiguration.getTitle(),
                             webHookConfiguration.getURL(),
-                            jsonBody);
+                            body);
                 }
-            } catch (IOException e)
+            }
+            catch (IOException e)
             {
                 LOGGER.error(
-                        "[repo: {}]| Something when wrong while posting the following body to webhook: [{}({})] \n{}",
+                        "[repo: {}]| Something went wrong while posting the following body to webhook: [{}({})] \n{}",
                         repo,
                         webHookConfiguration.getTitle(),
                         webHookConfiguration.getURL(),
-                        jsonBody,
+                        body,
                         e);
             }
-
         }
-    }
-
-    @Override
-    public void destroy() throws Exception
-    {
-        eventPublisher.unregister(this);
-        httpClient.close();
     }
 }

--- a/src/main/java/nl/topicus/bitbucket/api/RepositoryConfigServlet.java
+++ b/src/main/java/nl/topicus/bitbucket/api/RepositoryConfigServlet.java
@@ -75,7 +75,7 @@ public class RepositoryConfigServlet extends HttpServlet
 			ImmutableMap.Builder<String, Object> properties = ImmutableMap.<String, Object>builder().put("repository", repository);
 			if (id.isPresent())
 			{
-				WebHookConfiguration webHookConfiguration = webHookConfigurationDao.getWebHookConfigurations(id.get().getValue());
+				WebHookConfiguration webHookConfiguration = webHookConfigurationDao.getWebHookConfiguration(id.get().getValue());
 				if (webHookConfiguration != null && webHookConfiguration.getRepositoryId().equals(repository.getId()))
 				{
 					properties.put("configuration", webHookConfiguration);
@@ -91,7 +91,7 @@ public class RepositoryConfigServlet extends HttpServlet
 				Optional<NameValuePair> id = queryParams.stream().filter(param -> param.getName().equals("id")).findFirst();
 				if (id.isPresent())
 				{
-					WebHookConfiguration webHookConfiguration = webHookConfigurationDao.getWebHookConfigurations(id.get().getValue());
+					WebHookConfiguration webHookConfiguration = webHookConfigurationDao.getWebHookConfiguration(id.get().getValue());
 					if (webHookConfiguration != null && webHookConfiguration.getRepositoryId().equals(repository.getId()))
 					{
 						webHookConfigurationDao.deleteWebhookConfiguration(webHookConfiguration);
@@ -153,7 +153,9 @@ public class RepositoryConfigServlet extends HttpServlet
 		WebHookConfiguration webHookConfiguration = webHookConfigurationDao.createOrUpdateWebHookConfiguration(repository, id, title, url, enabled, isTagCreated, isBranchDeleted, isBranchCreated, isRepoPush, isPrDeclined, isPrRescoped, isPrMerged, isPrReopened, isPrUpdated, isPrCreated);
 		if (webHookConfiguration == null)
 		{
-			webHookConfiguration = new DummyWebHookConfiguration(title, url, enabled, isTagCreated, isBranchDeleted, isBranchCreated, isRepoPush, isPrDeclined, isPrRescoped, isPrMerged, isPrReopened, isPrUpdated, isPrCreated);
+			webHookConfiguration = new DummyWebHookConfiguration(repository.getId(), title, url, enabled,
+					isTagCreated, isBranchDeleted, isBranchCreated, isRepoPush, isPrDeclined, isPrRescoped,
+					isPrMerged, isPrReopened, isPrUpdated, isPrCreated);
 			String template = "nl.topicus.templates.edit";
 			render(resp, template, ImmutableMap.<String, Object>builder().put("repository", repository).put("configuration", webHookConfiguration).build());
 		}

--- a/src/main/java/nl/topicus/bitbucket/api/WebhookExceptionMapper.java
+++ b/src/main/java/nl/topicus/bitbucket/api/WebhookExceptionMapper.java
@@ -1,0 +1,19 @@
+package nl.topicus.bitbucket.api;
+
+import com.atlassian.bitbucket.rest.exception.UnhandledExceptionMapper;
+import com.atlassian.bitbucket.rest.exception.UnhandledExceptionMapperHelper;
+import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
+import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.sun.jersey.spi.resource.Singleton;
+
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Scanned // Force atlassian-spring-scanner to include this class; otherwise its @ComponentImport is ignored
+@Singleton
+public class WebhookExceptionMapper extends UnhandledExceptionMapper {
+
+    public WebhookExceptionMapper(@ComponentImport UnhandledExceptionMapperHelper helper) {
+        super(helper);
+    }
+}

--- a/src/main/java/nl/topicus/bitbucket/api/WebhookResource.java
+++ b/src/main/java/nl/topicus/bitbucket/api/WebhookResource.java
@@ -1,14 +1,14 @@
 package nl.topicus.bitbucket.api;
 
 import com.atlassian.bitbucket.repository.Repository;
-import com.atlassian.bitbucket.repository.RepositoryService;
-import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
+import com.atlassian.bitbucket.rest.util.ResourcePatterns;
 import nl.topicus.bitbucket.persistence.WebHookConfiguration;
 import nl.topicus.bitbucket.persistence.WebHookConfigurationDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
@@ -16,63 +16,56 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
-@Path("/projects/{projectKey}/repos/{repoSlug}/configurations")
+@Path(ResourcePatterns.REPOSITORY_URI + "/configurations")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class WebhookResource {
 
-    private RepositoryService repositoryService;
     private final WebHookConfigurationDao webHookConfigurationDao;
 
     @Autowired
-    public WebhookResource(@ComponentImport RepositoryService repositoryService, WebHookConfigurationDao webHookConfigurationDao) {
-        this.repositoryService = repositoryService;
+    public WebhookResource(WebHookConfigurationDao webHookConfigurationDao) {
         this.webHookConfigurationDao = webHookConfigurationDao;
     }
 
     @GET
-    public List<WebHookConfigurationModel> getWebhooks(@PathParam("projectKey") String projectKey, @PathParam("repoSlug") String repoSlug) {
-        Repository repo = repositoryService.getBySlug(projectKey, repoSlug);
-        if (repo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Repository not found").build());
-        }
-        return Arrays.stream(webHookConfigurationDao.getWebHookConfigurations(repo)).map(WebHookConfigurationModel::new).collect(Collectors.toList());
+    public List<WebHookConfigurationModel> getWebhooks(@Context Repository repo) {
+        return Arrays.stream(webHookConfigurationDao.getWebHookConfigurations(repo))
+                .map(WebHookConfigurationModel::new)
+                .collect(Collectors.toList());
     }
 
     @PUT
-    public WebHookConfigurationModel createWebhook(@PathParam("projectKey") String projectKey, @PathParam("repoSlug") String repoSlug, WebHookConfigurationModel newWebhook) {
-        Repository repo = repositoryService.getBySlug(projectKey, repoSlug);
-        if (repo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Repository not found").build());
-        }
-        WebHookConfiguration createdWebhook = webHookConfigurationDao.createOrUpdateWebHookConfiguration(repo, null, newWebhook.getTitle(), newWebhook.getUrl(), newWebhook.isEnabled());
-        return new WebHookConfigurationModel(createdWebhook);
+    public WebHookConfigurationModel createWebhook(@Context Repository repo, WebHookConfigurationModel newWebhook) {
+        return createOrUpdateWebhook(repo, null, newWebhook);
     }
 
     @Path("/{configId}")
     @POST
-    public WebHookConfigurationModel updateWebhook(@PathParam("projectKey") String projectKey, @PathParam("repoSlug") String repoSlug, WebHookConfigurationModel updatedWebhook, @PathParam("configId") String configId) {
-        Repository repo = repositoryService.getBySlug(projectKey, repoSlug);
-        if (repo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Repository not found").build());
-        }
-        WebHookConfiguration createdWebhook = webHookConfigurationDao.createOrUpdateWebHookConfiguration(repo, configId, updatedWebhook.getTitle(), updatedWebhook.getUrl(), updatedWebhook.isEnabled());
-        return new WebHookConfigurationModel(createdWebhook);
+    public WebHookConfigurationModel updateWebhook(@Context Repository repo, @PathParam("configId") String configId,
+                                                   WebHookConfigurationModel updatedWebhook) {
+        return createOrUpdateWebhook(repo, configId, updatedWebhook);
     }
 
     @Path("/{configId}")
     @DELETE
-    public void removeWebhook(@PathParam("projectKey") String projectKey, @PathParam("repoSlug") String repoSlug, @PathParam("configId") String configId) {
-        Repository repo = repositoryService.getBySlug(projectKey, repoSlug);
-        if (repo == null) {
-            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Repository not found").build());
-        }
-        WebHookConfiguration webhookCOnfiguration = webHookConfigurationDao.getWebHookConfigurations(configId);
+    public void removeWebhook(@Context Repository repo, @PathParam("configId") String configId) {
+        WebHookConfiguration webhookCOnfiguration = webHookConfigurationDao.getWebHookConfiguration(configId);
         if (webhookCOnfiguration == null) {
-            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND).entity("Webhook not found").build());
+            throw new WebApplicationException(Response.status(Response.Status.NOT_FOUND)
+                    .entity("Webhook not found")
+                    .build());
         }
         if (webhookCOnfiguration.getRepositoryId().equals(repo.getId())) {
             webHookConfigurationDao.deleteWebhookConfiguration(webhookCOnfiguration);
         }
+    }
+
+    private WebHookConfigurationModel createOrUpdateWebhook(Repository repo, String configId,
+                                                            WebHookConfigurationModel updatedWebhook) {
+        WebHookConfiguration createdWebhook = webHookConfigurationDao.createOrUpdateWebHookConfiguration(
+                repo, configId, updatedWebhook.getTitle(), updatedWebhook.getUrl(), updatedWebhook.isEnabled());
+
+        return new WebHookConfigurationModel(createdWebhook);
     }
 }

--- a/src/main/java/nl/topicus/bitbucket/events/EventType.java
+++ b/src/main/java/nl/topicus/bitbucket/events/EventType.java
@@ -1,30 +1,37 @@
 package nl.topicus.bitbucket.events;
 
+import javax.annotation.Nonnull;
+
+import static java.util.Objects.requireNonNull;
+import static nl.topicus.bitbucket.persistence.WebHookConfiguration.*;
+
 public enum EventType {
     
-    PULL_REQUEST_CREATED("pullrequest:created", "PR_CREATED"),
-    PULL_REQUEST_UPDATED("pullrequest:updated", "PR_UPDATED"),
-    PULL_REQUEST_RESCOPED("pullrequest:updated", "PR_RESCOPED"),
-    PULL_REQUEST_REOPENED("pullrequest:updated", "PR_REOPENED"),
-    PULL_REQUEST_MERGED("pullrequest:fulfilled", "PR_MERGED"),
-    PULL_REQUEST_DECLINED("pullrequest:rejected", "PR_DECLINED"),
-    REPO_PUSH("repo:push", "REPO_PUSH"),
-    TAG_CREATED("repo:push", "TAG_CREATED"),
-    BRANCH_CREATED("repo:push", "BRANCH_CREATED"),
-    BRANCH_DELETED("repo:push", "BRANCH_DELETED"),;
+    PULL_REQUEST_CREATED("pullrequest:created", COLUMN_PR_CREATED),
+    PULL_REQUEST_UPDATED("pullrequest:updated", COLUMN_PR_UPDATED),
+    PULL_REQUEST_RESCOPED("pullrequest:updated", COLUMN_PR_RESCOPED),
+    PULL_REQUEST_REOPENED("pullrequest:updated", COLUMN_PR_REOPENED),
+    PULL_REQUEST_MERGED("pullrequest:fulfilled", COLUMN_PR_MERGED),
+    PULL_REQUEST_DECLINED("pullrequest:rejected", COLUMN_PR_DECLINED),
+    REPO_PUSH("repo:push", COLUMN_REPO_PUSH),
+    TAG_CREATED("repo:push", COLUMN_TAG_CREATED),
+    BRANCH_CREATED("repo:push", COLUMN_BRANCH_CREATED),
+    BRANCH_DELETED("repo:push", COLUMN_BRANCH_DELETED),;
 
     private final String headerValue;
     private final String queryColumn;
 
     EventType(String headerValue, String queryColumn) {
-        this.headerValue = headerValue;
-        this.queryColumn = queryColumn;
+        this.headerValue = requireNonNull(headerValue, "headerValue");
+        this.queryColumn = requireNonNull(queryColumn, "queryColumn");
     }
 
+    @Nonnull
     public String getHeaderValue() {
         return headerValue;
     }
 
+    @Nonnull
     public String getQueryColumn() {
         return queryColumn;
     }

--- a/src/main/java/nl/topicus/bitbucket/persistence/DummyWebHookConfiguration.java
+++ b/src/main/java/nl/topicus/bitbucket/persistence/DummyWebHookConfiguration.java
@@ -23,11 +23,12 @@ public class DummyWebHookConfiguration implements WebHookConfiguration
 	private boolean isPrUpdated;
 	private boolean isPrCreated;
 
-	public DummyWebHookConfiguration(String title, String url, boolean enabled, boolean isTagCreated,
+	public DummyWebHookConfiguration(int repoId, String title, String url, boolean enabled, boolean isTagCreated,
 									 boolean isBranchDeleted, boolean isBranchCreated, boolean isRepoPush,
 									 boolean isPrDeclined, boolean isPrRescoped, boolean isPrMerged,
 									 boolean isPrReopened, boolean isPrUpdated, boolean isPrCreated)
 	{
+		this.repoId = repoId;
 		this.title = title;
 		this.URL = url;
 		this.enabled = enabled;
@@ -71,12 +72,6 @@ public class DummyWebHookConfiguration implements WebHookConfiguration
 	public Integer getRepositoryId()
 	{
 		return repoId;
-	}
-
-	@Override
-	public void setRepositoryId(Integer repoId)
-	{
-		this.repoId = repoId;
 	}
 
 	@Override

--- a/src/main/java/nl/topicus/bitbucket/persistence/WebHookConfiguration.java
+++ b/src/main/java/nl/topicus/bitbucket/persistence/WebHookConfiguration.java
@@ -4,122 +4,132 @@ import net.java.ao.Accessor;
 import net.java.ao.Entity;
 import net.java.ao.Mutator;
 import net.java.ao.Preload;
-import net.java.ao.schema.Default;
-import net.java.ao.schema.NotNull;
-import net.java.ao.schema.StringLength;
-import net.java.ao.schema.Table;
+import net.java.ao.schema.*;
 
 @Table("WHConfig")
 @Preload
 public interface WebHookConfiguration extends Entity
 {
+	String COLUMN_BRANCH_CREATED = "BRANCH_CREATED";
+	String COLUMN_BRANCH_DELETED = "BRANCH_DELETED";
+	String COLUMN_ENABLED = "IS_ENABLED";
+	String COLUMN_REPO_ID = "REPO_ID";
+	String COLUMN_PR_CREATED = "PR_CREATED";
+	String COLUMN_PR_DECLINED = "PR_DECLINED";
+	String COLUMN_PR_MERGED = "PR_MERGED";
+	String COLUMN_PR_RESCOPED = "PR_RESCOPED";
+	String COLUMN_PR_REOPENED = "PR_REOPENED";
+	String COLUMN_PR_UPDATED = "PR_UPDATED";
+	String COLUMN_REPO_PUSH = "REPO_PUSH";
+	String COLUMN_TAG_CREATED = "TAG_CREATED";
+	String COLUMN_TITLE = "TITLE";
+	String COLUMN_URL = "URL";
+
+	@Accessor(COLUMN_TITLE)
 	@NotNull
-	@Accessor("TITLE")
 	String getTitle();
 
-	@Mutator("TITLE")
+	@Mutator(COLUMN_TITLE)
 	void setTitle(String title);
 
+	@Accessor(COLUMN_URL)
 	@NotNull
-	@Accessor("URL")
+	@StringLength(StringLength.UNLIMITED)
 	String getURL();
 
-	@Mutator("URL")
-	@StringLength(StringLength.UNLIMITED)
+	@Mutator(COLUMN_URL)
 	void setURL(String URL);
 
+	@Accessor(COLUMN_REPO_ID)
+	@Indexed
 	@NotNull
-	@Accessor("REPO_ID")
 	Integer getRepositoryId();
 
-	@Mutator("REPO_ID")
-	void setRepositoryId(Integer repoId);
-
-	@NotNull
+	@Accessor(COLUMN_ENABLED)
 	@Default("true")
-	@Accessor("IS_ENABLED")
+	@NotNull
 	boolean isEnabled();
 
-	@Mutator("IS_ENABLED")
+	@Mutator(COLUMN_ENABLED)
 	void setEnabled(boolean isEnabled);
 
 	@NotNull
 	@Default("true")
-	@Accessor("PR_CREATED")
+	@Accessor(COLUMN_PR_CREATED)
 	boolean isPrCreated();
 
-	@Mutator("PR_CREATED")
+	@Mutator(COLUMN_PR_CREATED)
 	void setPrCreated(boolean isPrCreated);
 
 	@NotNull
 	@Default("true")
-	@Accessor("PR_UPDATED")
+	@Accessor(COLUMN_PR_UPDATED)
 	boolean isPrUpdated();
 
-	@Mutator("PR_UPDATED")
+	@Mutator(COLUMN_PR_UPDATED)
 	void setPrUpdated(boolean isPrUpdated);
 
 	@NotNull
 	@Default("true")
-	@Accessor("PR_REOPENED")
+	@Accessor(COLUMN_PR_REOPENED)
 	boolean isPrReopened();
 
-	@Mutator("PR_REOPENED")
+	@Mutator(COLUMN_PR_REOPENED)
 	void setPrReopened(boolean isPrReopened);
 
 	@NotNull
 	@Default("true")
-	@Accessor("PR_MERGED")
+	@Accessor(COLUMN_PR_MERGED)
 	boolean isPrMerged();
 
-	@Mutator("PR_MERGED")
+	@Mutator(COLUMN_PR_MERGED)
 	void setPrMerged(boolean isPrMerged);
 
 	@NotNull
 	@Default("true")
-	@Accessor("PR_RESCOPED")
+	@Accessor(COLUMN_PR_RESCOPED)
 	boolean isPrRescoped();
 
-	@Mutator("PR_RESCOPED")
+	@Mutator(COLUMN_PR_RESCOPED)
 	void setPrRescoped(boolean isPrRescoped);
 
 	@NotNull
 	@Default("true")
-	@Accessor("PR_DECLINED")
+	@Accessor(COLUMN_PR_DECLINED)
 	boolean isPrDeclined();
 
-	@Mutator("PR_DECLINED")
+	@Mutator(COLUMN_PR_DECLINED)
 	void setPrDeclined(boolean isPrDeclined);
 
 	@NotNull
 	@Default("true")
-	@Accessor("REPO_PUSH")
+	@Accessor(COLUMN_REPO_PUSH)
 	boolean isRepoPush();
 
-	@Mutator("REPO_PUSH")
+	@Mutator(COLUMN_REPO_PUSH)
 	void setRepoPush(boolean isRepoPush);
 
 	@NotNull
 	@Default("true")
-	@Accessor("BRANCH_CREATED")
+	@Accessor(COLUMN_BRANCH_CREATED)
 	boolean isBranchCreated();
 
-	@Mutator("BRANCH_CREATED")
+	@Mutator(COLUMN_BRANCH_CREATED)
 	void setBranchCreated(boolean isBranchCreated);
 
 	@NotNull
 	@Default("true")
-	@Accessor("BRANCH_DELETED")
+	@Accessor(COLUMN_BRANCH_DELETED)
 	boolean isBranchDeleted();
 
-	@Mutator("BRANCH_DELETED")
+	@Mutator(COLUMN_BRANCH_DELETED)
 	void setBranchDeleted(boolean isBranchDeleted);
 
 	@NotNull
 	@Default("false")
-	@Accessor("TAG_CREATED")
+	@Accessor(COLUMN_TAG_CREATED)
 	boolean isTagCreated();
 
-	@Mutator("TAG_CREATED")
+	@Mutator(COLUMN_TAG_CREATED)
 	void setTagCreated(boolean isTagCreated);
 }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -6,9 +6,6 @@
         <param name="plugin-icon">images/pluginIcon.png</param>
         <param name="plugin-logo">images/pluginLogo.png</param>
         <param name="atlassian-data-center-compatible">true</param>
-        <permissions>
-            <permission>execute_java</permission>
-        </permissions>
     </plugin-info>
 
     <ao key="ao-module">

--- a/src/test/java/it/nl/topicus/bitbucket/WebhookResourceTest.java
+++ b/src/test/java/it/nl/topicus/bitbucket/WebhookResourceTest.java
@@ -1,0 +1,122 @@
+package it.nl.topicus.bitbucket;
+
+import com.atlassian.bitbucket.project.NoSuchProjectException;
+import com.atlassian.bitbucket.repository.NoSuchRepositoryException;
+import com.atlassian.bitbucket.test.BaseRetryingFuncTest;
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.http.ContentType;
+import net.sf.json.JSONObject;
+import org.junit.Test;
+
+import static com.atlassian.bitbucket.test.DefaultFuncTestData.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class WebhookResourceTest extends BaseRetryingFuncTest {
+
+    @Test
+    public void testCrudWebhook() { // For simplicity, this tests creating, reading, updating and deleting a webhook
+        JSONObject body = new JSONObject();
+        body.put("title", "Test Hook");
+        body.put("url", "https://example.com/webhook");
+        body.put("enabled", true);
+
+        // Create
+        int webhookId = RestAssured.given()
+                .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                .body(body)
+                .contentType(ContentType.JSON)
+                .expect().statusCode(200)
+                .log().ifValidationFails()
+                .body("title", equalTo(body.get("title")))
+                .body("url", equalTo(body.get("url")))
+                .body("enabled", equalTo(true))
+                .when().put(getUrl(getProject1(), getProject1Repository1()))
+                .jsonPath()
+                .getInt("id");
+
+        try {
+            // Read
+            RestAssured.given()
+                    .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                    .expect().statusCode(200)
+                    .log().ifValidationFails()
+                    .body("size()", equalTo(1))
+                    .body("[0].id", equalTo(webhookId))
+                    .body("[0].title", equalTo(body.get("title")))
+                    .body("[0].url", equalTo(body.get("url")))
+                    .body("[0].enabled", equalTo(true))
+                    .when().get(getUrl(getProject1(), getProject1Repository1()));
+
+            JSONObject update = new JSONObject();
+            update.put("id", webhookId);
+            update.put("title", "Updated Test");
+            update.put("url", "http://example.com/webhook");
+            update.put("enabled", false);
+
+            // Update
+            RestAssured.given()
+                    .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                    .body(update)
+                    .contentType(ContentType.JSON)
+                    .expect().statusCode(200)
+                    .log().ifValidationFails()
+                    .body("id", equalTo(webhookId))
+                    .body("title", equalTo(update.get("title")))
+                    .body("url", equalTo(update.get("url")))
+                    .body("enabled", equalTo(false))
+                    .when().post(getUrl(getProject1(), getProject1Repository1()) + "/" + webhookId);
+        } finally {
+            RestAssured.given()
+                    .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                    .expect().statusCode(204)
+                    .log().ifValidationFails()
+                    .when().delete(getUrl(getProject1(), getProject1Repository1()) + "/" + webhookId);
+        }
+    }
+
+    @Test
+    public void testGetWebhooksForNonexistentProject() {
+        RestAssured.given()
+                .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                .expect().statusCode(404)
+                .log().ifValidationFails()
+                .body("errors[0].exceptionName", equalTo(NoSuchProjectException.class.getCanonicalName()))
+                .body("errors[0].message", equalTo("Project NONE does not exist."))
+                .when().get(getUrl("NONE", "nonexistent"));
+    }
+
+    @Test
+    public void testGetWebhooksForNonexistentRepository() {
+        RestAssured.given()
+                .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                .expect().statusCode(404)
+                .log().ifValidationFails()
+                .body("errors[0].exceptionName", equalTo(NoSuchRepositoryException.class.getCanonicalName()))
+                .body("errors[0].message", equalTo("Repository " + getProject1() + "/nonexistent does not exist."))
+                .when().get(getUrl(getProject1(), "nonexistent"));
+    }
+
+    @Test
+    public void testGetWebhooksWithNoneConfigured() {
+        RestAssured.given()
+                .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                .expect().statusCode(200)
+                .log().ifValidationFails()
+                .body("isEmpty()", equalTo(true))
+                .when().get(getUrl(getProject1(), getProject1Repository1()));
+    }
+
+    @Test
+    public void testRemoveWebhookWithNonexistentId() {
+        RestAssured.given()
+                .auth().preemptive().basic(getAdminUser(), getAdminPassword())
+                .expect().statusCode(404)
+                .log().ifValidationFails()
+                .body(equalTo("Webhook not found"))
+                .when().delete(getUrl(getProject1(), getProject1Repository1()) + "/9999");
+    }
+
+    private String getUrl(String projectKey, String repositorySlug) {
+        return getRepositoryRestURL("webhook", "latest", projectKey, repositorySlug) + "/configurations";
+    }
+}

--- a/src/test/java/nl/topicus/bitbucket/persistence/WebHookConfigurationDaoTest.java
+++ b/src/test/java/nl/topicus/bitbucket/persistence/WebHookConfigurationDaoTest.java
@@ -1,0 +1,138 @@
+package nl.topicus.bitbucket.persistence;
+
+import com.atlassian.activeobjects.external.ActiveObjects;
+import com.atlassian.activeobjects.test.TestActiveObjects;
+import com.atlassian.bitbucket.ao.AbstractAoDaoTest;
+import com.atlassian.bitbucket.repository.Repository;
+import net.java.ao.test.jdbc.Data;
+import nl.topicus.bitbucket.events.EventType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Data(WebHookConfigurationDatabaseUpdater.class)
+public class WebHookConfigurationDaoTest extends AbstractAoDaoTest {
+
+    private ActiveObjects activeObjects;
+    private WebHookConfigurationDao dao;
+
+    public WebHookConfigurationDaoTest() {
+        super(WebHookConfiguration.class);
+    }
+
+    @Before
+    public void setup() {
+        activeObjects = new TestActiveObjects(entityManager);
+        dao = new WebHookConfigurationDao(activeObjects);
+    }
+
+    @Test
+    public void testCreateOrUpdateWebHookConfigurationForCreate() {
+        WebHookConfiguration created = dao.createOrUpdateWebHookConfiguration(mockRepository(3),
+                null, "Bamboo", "https://example.com/bamboo/webhook", true);
+        assertNotNull(created);
+        assertEquals(Integer.valueOf(3), created.getRepositoryId());
+        assertEquals("Bamboo", created.getTitle());
+        assertEquals("https://example.com/bamboo/webhook", created.getURL());
+        assertTrue(created.isEnabled());
+    }
+
+    @Test
+    public void testCreateOrUpdateWebHookConfigurationForUpdate() {
+        WebHookConfiguration[] configurations = activeObjects.find(WebHookConfiguration.class);
+        assumeTrue(configurations != null && configurations.length > 0);
+
+        WebHookConfiguration existing = configurations[0];
+
+        WebHookConfiguration updated = dao.createOrUpdateWebHookConfiguration(
+                mockRepository(existing.getRepositoryId()), String.valueOf(existing.getID()),
+                "Updated", "https://example.com/updated/webhook", !existing.isEnabled());
+        assertNotNull(updated);
+        assertEquals(existing.getRepositoryId(), updated.getRepositoryId());
+        assertEquals("Updated", updated.getTitle());
+        assertEquals("https://example.com/updated/webhook", updated.getURL());
+        assertEquals(!existing.isEnabled(), updated.isEnabled());
+    }
+
+    @Test
+    public void testDeleteWebhookConfiguration() {
+        WebHookConfiguration[] configurations = activeObjects.find(WebHookConfiguration.class);
+        assumeTrue(configurations != null && configurations.length > 0);
+
+        WebHookConfiguration configuration = configurations[0];
+        dao.deleteWebhookConfiguration(configuration);
+
+        assertNull(activeObjects.get(WebHookConfiguration.class, configuration.getID()));
+    }
+
+    @Test
+    public void testDeleteWebhookConfigurations() {
+        Repository repo = mockRepository(2);
+        assertEquals(2, dao.deleteWebhookConfigurations(repo));
+
+        WebHookConfiguration[] configurations = dao.getWebHookConfigurations(repo);
+        assertTrue(configurations == null || configurations.length == 0);
+    }
+    
+    @Test
+    public void testDeleteWebhookConfigurationsForUnconfiguredRepository() {
+        assertEquals(0, dao.deleteWebhookConfigurations(mockRepository(99)));
+    }
+
+    @Test
+    public void testGetEnabledWebHookConfigurations() {
+        WebHookConfiguration[] configurations = dao.getEnabledWebHookConfigurations(mockRepository(2), EventType.REPO_PUSH);
+        assertNotNull(configurations);
+        assertEquals(1, configurations.length);
+
+        WebHookConfiguration configuration = configurations[0];
+        assertEquals(Integer.valueOf(2), configuration.getRepositoryId());
+        assertEquals("HipChat", configuration.getTitle());
+        assertEquals("https://example.com/hipchat/webhook", configuration.getURL());
+        assertTrue(configuration.isEnabled());
+    }
+
+    @Test
+    public void testGetWebHookConfiguration() {
+        WebHookConfiguration[] configurations = activeObjects.find(WebHookConfiguration.class);
+        assumeTrue(configurations != null && configurations.length > 0);
+
+        WebHookConfiguration expected = configurations[0];
+
+        WebHookConfiguration actual = dao.getWebHookConfiguration(String.valueOf(expected.getID()));
+        assertEquals(expected.getRepositoryId(), actual.getRepositoryId());
+        assertEquals(expected.getTitle(), actual.getTitle());
+        assertEquals(expected.getURL(), actual.getURL());
+        assertEquals(expected.isEnabled(), actual.isEnabled());
+    }
+
+    @Test
+    public void testGetWebHookConfigurations() {
+        WebHookConfiguration[] configurations = dao.getWebHookConfigurations(mockRepository(2));
+        assertNotNull(configurations);
+        assertEquals(2, configurations.length);
+
+        WebHookConfiguration hipchat = configurations[0];
+        assertEquals(Integer.valueOf(2), hipchat.getRepositoryId());
+        assertEquals("HipChat", hipchat.getTitle());
+        assertEquals("https://example.com/hipchat/webhook", hipchat.getURL());
+        assertTrue(hipchat.isEnabled());
+
+        WebHookConfiguration slack = configurations[1];
+        assertEquals(Integer.valueOf(2), slack.getRepositoryId());
+        assertEquals("Slack", slack.getTitle());
+        assertEquals("https://example.com/slack/webhook", slack.getURL());
+        assertFalse(slack.isEnabled());
+    }
+
+    private static Repository mockRepository(int id) {
+        Repository repository = mock(Repository.class);
+        when(repository.getId()).thenReturn(id);
+
+        return repository;
+    }
+}

--- a/src/test/java/nl/topicus/bitbucket/persistence/WebHookConfigurationDatabaseUpdater.java
+++ b/src/test/java/nl/topicus/bitbucket/persistence/WebHookConfigurationDatabaseUpdater.java
@@ -1,0 +1,36 @@
+package nl.topicus.bitbucket.persistence;
+
+import com.google.common.collect.ImmutableMap;
+import net.java.ao.EntityManager;
+import net.java.ao.test.jdbc.DatabaseUpdater;
+
+import static nl.topicus.bitbucket.persistence.WebHookConfiguration.*;
+
+public class WebHookConfigurationDatabaseUpdater implements DatabaseUpdater {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void update(EntityManager entityManager) throws Exception {
+        entityManager.migrate(WebHookConfiguration.class);
+
+        entityManager.create(WebHookConfiguration.class, ImmutableMap.<String, Object>builder()
+                .put(COLUMN_ENABLED, true)
+                .put(COLUMN_REPO_ID, 1)
+                .put(COLUMN_TITLE, "Jenkins")
+                .put(COLUMN_URL, "https://example.com/jenkins/webhook")
+                .build());
+
+        entityManager.create(WebHookConfiguration.class, ImmutableMap.<String, Object>builder()
+                .put(COLUMN_ENABLED, true)
+                .put(COLUMN_REPO_ID, 2)
+                .put(COLUMN_TITLE, "HipChat")
+                .put(COLUMN_URL, "https://example.com/hipchat/webhook")
+                .build());
+        entityManager.create(WebHookConfiguration.class, ImmutableMap.<String, Object>builder()
+                .put(COLUMN_ENABLED, false)
+                .put(COLUMN_REPO_ID, 2)
+                .put(COLUMN_TITLE, "Slack")
+                .put(COLUMN_URL, "https://example.com/slack/webhook")
+                .build());
+    }
+}


### PR DESCRIPTION
- Fixed dependencies
  - bitbucket-page-objects is not provided; it can only be _correctly_ used in <scope>test</scope>
  - Moved Jackson to <scope>provided</scope> so it won't be bundled in the plugin; Bitbucket Server provides it
  - Removed unused dependencies
    - gson, javax.inject, sal-api
    - gson was previously being bundled in the plugin, even though it was never used
- Added an @EventListener for RepositoryDeletionRequestedEvent to delete WebHookConfiguration rows when repositories are removed
- Added an index to WebHookConfiguration.getRepositoryId() to avoid performing full table scans for every query
- Added constants for WebHookConfiguration column names, and removed the unused mutator for the repository ID
- Added a set of unit tests for WebHookConfigurationDao, and added a Maven profile to facilitate running them against real databases, not just H2
- Simplified WebhookResource, using Bitbucket Server's "magic" @Context injection for Repository instances
  - The URL is now defined using a constant, but its structure is still the same as before--this is not a breaking change
- Added WebhookExceptionMapper, which applies shared handling for known exception types
  - This makes various REST errors from the plugin consistent with how they would be messages by Bitbucket Server's own REST APIs
- Moved all PullRequestListener handling onto executor threads, to avoid triggering pull request merges and webhooks on Bitbucket Server's (very limited) event threads
- Updated Models.createRepository to use a ProjectVisitor, rather than directly casting the Project instance
  - This is a little extra code, but it's "safer" when the object you're dealing with may be proxied by Hibernate
- Added REST (integration) tests for WebhookResource
  - In addition to verifying the REST endpoint's behavior, this has the side benefit of verifying that the plugin starts correctly
- Switched back to handling RepositoryRefsChangedEvent, instead of only specific subtypes, and instead use the event's class to determine the correct EventType

Some of these changes are opinionated (event method renaming), and may be ignored if preferred.

It's entirely possible the maintainers will not want to merge this pull request all in one lump. It's pretty big. Hopefully the changes are at least illustrative and useful, even if this pull request is not accepted directly.

/cc @casz 