### PR TITLE
Configure atlassian-data-center-status (#117)

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -5,6 +5,7 @@
         <vendor name="${project.organization.name}" url="${project.organization.url}"/>
         <param name="plugin-icon">images/pluginIcon.png</param>
         <param name="plugin-logo">images/pluginLogo.png</param>
+	<param name="atlassian-data-center-status">compatible</param>
         <param name="atlassian-data-center-compatible">true</param>
     </plugin-info>
 

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -5,8 +5,8 @@
         <vendor name="${project.organization.name}" url="${project.organization.url}"/>
         <param name="plugin-icon">images/pluginIcon.png</param>
         <param name="plugin-logo">images/pluginLogo.png</param>
-	<param name="atlassian-data-center-status">compatible</param>
-	<param name="atlassian-data-center-compatible">true</param>
+        <param name="atlassian-data-center-status">compatible</param>
+        <param name="atlassian-data-center-compatible">true</param>
     </plugin-info>
 
     <ao key="ao-module">

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -6,7 +6,7 @@
         <param name="plugin-icon">images/pluginIcon.png</param>
         <param name="plugin-logo">images/pluginLogo.png</param>
 	<param name="atlassian-data-center-status">compatible</param>
-        <param name="atlassian-data-center-compatible">true</param>
+	<param name="atlassian-data-center-compatible">true</param>
     </plugin-info>
 
     <ao key="ao-module">


### PR DESCRIPTION
Added `atlassian-data-center-status` to mark plugin to be `compatible` with Bitbucket Datacenter version as per #117 .