### PR TITLE
improved description for pull-request update trigger

### DIFF
--- a/src/main/resources/templates/templates.soy
+++ b/src/main/resources/templates/templates.soy
@@ -211,7 +211,7 @@
                  {param legendContent: '' /}
                  {param fields: [[
                    'id': 'isPrUpdated',
-                   'labelText': 'Pull request updated',
+                   'labelText': 'Pull request description updated',
                    'isChecked': $configuration ? $configuration.prUpdated : false
                  ]] /}
                 {/call}


### PR DESCRIPTION
As described in https://github.com/Eernie/bitbucket-webhooks-plugin/issues/120 BitBucket Server has no support for notifying event-listeners of code-updates in pull-requests.
Only for changes in "title, description, or target branch".

I changed the labelText of the corresponding option, to better reflect this situation and avoid confusion.